### PR TITLE
Add option to read input file from server path in prediction form

### DIFF
--- a/flaskInterface.py
+++ b/flaskInterface.py
@@ -21,7 +21,7 @@ def index():
     trainForm = TrainForm()
     testForm = TestForm()
 
-    if trainForm.submit.data and trainForm.validate_on_submit():
+    if trainForm.submitTrain.data and trainForm.validate_on_submit():
         if request.method == "POST":
             if os.path.exists('temp'):
                 directoryUtils.rmtree("temp")
@@ -43,7 +43,7 @@ def index():
             w.close()
             return redirect(url_for('trainResults'))            
 
-    if testForm.submit.data and testForm.validate_on_submit():
+    if testForm.submitTest.data and testForm.validate_on_submit():
         if request.method == "POST":
             if os.path.exists('temp'):
                 directoryUtils.rmtree("temp")
@@ -64,16 +64,21 @@ def index():
             else:
                 return 'Invalid labels.'
 
-            for f in testForm.images.data:
-                if allowed_file(secure_filename(f.filename), ['jpeg', 'jpg', 'png']):
-                    f.save(os.path.join('temp', 'images', secure_filename(f.filename)))
+            # process based on source
+            print('Beginning handover to prediction script.')
+            if testForm.source.data == 'images':
+                for f in testForm.images.data:
+                    if allowed_file(secure_filename(f.filename), ['jpeg', 'jpg', 'png']):
+                        f.save(os.path.join('temp', 'images', secure_filename(f.filename)))
+                modelPredict.predict('temp')
+                directoryUtils.rmtree("temp")
+                return render_template("testResults.html")
 
-            print("Beginning handover to prediction script.")
-            modelPredict.predict()
-
-            directoryUtils.rmtree("temp")
-
-            return render_template("testResults.html")
+            elif testForm.source.data == 'path':
+                modelPredict.predict(testForm.path.data)
+                directoryUtils.rmtree("temp")            
+                testForm.messages = ['Prediction success. Images have been sorted in the same path']
+                return render_template("HTML_Interface.html", trainForm = TrainForm(), testForm = testForm)
 
     return render_template("HTML_Interface.html", trainForm = trainForm, testForm = testForm)
 

--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
-from wtforms import MultipleFileField, DecimalField, IntegerField, SubmitField, FileField
-from wtforms.validators import NumberRange, InputRequired
+from wtforms import MultipleFileField, DecimalField, IntegerField, SubmitField, FileField, RadioField, StringField
+from wtforms.validators import ValidationError, NumberRange, InputRequired
 
 class TrainForm(FlaskForm):
     images = MultipleFileField("Images: ", [InputRequired(),])
@@ -8,10 +8,21 @@ class TrainForm(FlaskForm):
     height = IntegerField("Height: ", [InputRequired(), NumberRange(min = 100, max = 2000)], default=256)
     split = DecimalField("Split: ", [InputRequired(), NumberRange(min = 0.0, max = 1.0, message = ("Split must be between 0.0 and 1.0."))], default=0.8)
     epochs = IntegerField("Number of epochs: ", [InputRequired(), NumberRange(min = 1, message = ("A minimum of one epoch must be trained."))], default=10)
-    submit = SubmitField("Submit")
+    submitTrain = SubmitField("Submit")
+
+def required_if_selected_by(select_field):
+    message = f'Must be provided if selected by {select_field}'
+    def call(form, field):   
+        if form[select_field].data == field.name:
+            required =  InputRequired(message)
+            required(form, field)
+    return call
 
 class TestForm(FlaskForm):
-    images = MultipleFileField("Images: ")
-    model = FileField("Model: ")
-    labels = FileField("Labels: ")
-    submit = SubmitField("Submit")
+    source = RadioField("Source: ", choices=[('images', 'Images'), ('path', 'Path')], default='images')
+    path = StringField("Path:", [required_if_selected_by('source')])
+    images = MultipleFileField("Images: ", [required_if_selected_by('source')])
+    model = FileField("Model: ", [InputRequired(),])
+    labels = FileField("Labels: ", [InputRequired(),])
+    submitTest = SubmitField("Submit")
+    messages = []

--- a/imageUploadUtils.py
+++ b/imageUploadUtils.py
@@ -23,16 +23,20 @@ def getAllTrainImages(directory, dim=(256, 256)):
     print("Read and resize complete.")
     return images, labels, classes
 
-def getAllPredictImages(directory, dim=(256, 256)):
-    allFiles = os.listdir(os.path.join(directory, "images"))
+def getAllPredictImages(directory, dim=(256, 256), subdir=None):
+    if subdir:
+        directory = os.path.join(directory, subdir)
+    allFiles = os.listdir(directory)
 
     images = []
+    names = []
 
     print("Beginning image read and resize process.")
     for file in allFiles:
-        img = cv2.imread(os.path.join(directory, "images", file)) 
+        img = cv2.imread(os.path.join(directory, file)) 
         resized = cv2.resize(img, dim)
         images.append(resized)
+        names.append(file)
     
     print("Read and resize complete.")
-    return np.array(images)
+    return np.array(images), names

--- a/templates/HTML_Interface.html
+++ b/templates/HTML_Interface.html
@@ -53,6 +53,20 @@
       align-items: center;
       text-align: center;
     }
+    ul#source , ul#source li {
+      display: inline;
+      list-style: none;
+      padding-left: 0px;
+    }
+    ul#source li input[type=radio] {
+      height: auto;
+    }
+    form .errors {
+      color: red;
+    }
+    form .messages {
+      color: green;
+    }
   </style>
 </head>
 
@@ -104,7 +118,7 @@
             <br>
             {% endif %}
   
-            {{ trainForm.submit }}
+            {{ trainForm.submitTrain }}
   
         </p>
         </form>
@@ -129,35 +143,33 @@
             <form id="demo2" action="/" enctype="multipart/form-data" method="POST">
            
               {{ testForm.hidden_tag() }}
+              {{ testForm.source.label }} {{ testForm.source }} <br><br>
               {{ testForm.images.label }} {{ testForm.images(webkitdirectory='true') }} <br><br>
+              {{ testForm.path.label }} {{ testForm.path(placeholder='C:\\dataset\\test_images') }} <br><br>
               {{ testForm.model.label }} {{ testForm.model }}<br><br>
               {{ testForm.labels.label }} {{ testForm.labels }}<br><br>
-    
-              {% if testForm.images.errors %}
-              <ul>
-                {% for error in testForm.images.errors %}
-                <li> {{ error }} </li>
-                {% endfor %}
+
+              {% if testForm.messages %}
+              <ul class="messages">                  
+                  {% for msg in testForm.messages %}
+                      <li>{{ msg }}</li>
+                  {% endfor %}                  
               </ul>
+              <br>
+              {% endif %}
+
+              {% if testForm.errors %}
+              <ul class="errors">
+                  {% for field_name, field_errors in testForm.errors|dictsort if field_errors %}
+                      {% for error in field_errors %}
+                          <li>{{ testForm[field_name].label }}: {{ error }}</li>
+                      {% endfor %}
+                  {% endfor %}
+              </ul>
+              <br>
               {% endif %}
     
-              {% if testForm.model.errors %}
-              <ul>
-                {% for error in testForm.model.errors %}
-                <li> {{ error }} </li>
-                {% endfor %}
-              </ul>
-              {% endif %}
-    
-              {% if testForm.labels.errors %}
-              <ul>
-                {% for error in testForm.labels.errors %}
-                <li> {{ error }} </li>
-                {% endfor %}
-              </ul>
-              {% endif %}
-    
-              {{ testForm.submit }}
+              {{ testForm.submitTest }}
             </p>
           </form>
           <form action="{{ url_for('download', folder = 'test') }}">


### PR DESCRIPTION
1. Add text input to allow the use of (server) path as input source for prediction
2. Add radio button to choose input source (file upload or server path)
3. If path is used, create predictions folder and label/class subfolders within in the images directory path. Then copy the images (retaining original filename) to the subfolders based on prediction result. On success, return to the same page `HTML_Interface.html` showing success message